### PR TITLE
Class-based fact definition (using Python 3.6 annotations)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 pymorphy2==0.8
 backports.functools-lru-cache==1.3
 intervaltree==2.1.0
+six==1.11.0
 
 # dev
 pytest==3.2.1

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ REQUIREMENTS = [
     'pymorphy2==0.8',
     'backports.functools-lru-cache==1.3',
     'intervaltree==2.1.0',
+    'six==1.11.0',
 ]
 
 setup(

--- a/tox.ini
+++ b/tox.ini
@@ -5,3 +5,4 @@
 pep8ignore =
     W503
     E501
+    yargy/tests/test_class_based_fact_definition.py E701

--- a/yargy/interpretation/fact.py
+++ b/yargy/interpretation/fact.py
@@ -81,8 +81,13 @@ class FactDefinitionMeta(type):
         if class_attr.get('_ROOT_FACT_DEFINITION', False):
             # Checking for attempt to redeclare base definition class
             if mcs.BASE_FACT_DEFINITION_CLS is not None:
-                raise TypeError(f"Attempt to redeclare base fact definition class "
-                                f"'{mcs.BASE_FACT_DEFINITION_CLS.__name__}' by '{typename}'")
+                raise TypeError(
+                    "Attempt to redeclare base fact definition class"
+                    " '{current_base_cls_name}' by '{new_base_cls_name}'".format(
+                        current_base_cls_name=mcs.BASE_FACT_DEFINITION_CLS.__name__,
+                        new_base_cls_name=typename
+                    )
+                )
 
             # Saving root class to metaclass attributes
             mcs.BASE_FACT_DEFINITION_CLS = super().__new__(mcs, typename, base_classes, class_attr)
@@ -94,15 +99,15 @@ class FactDefinitionMeta(type):
         # TODO CONSIDER: research ability of mixins support
         # TODO CONSIDER: research ability of transitive inheritance from base class
         if base_classes != (mcs.BASE_FACT_DEFINITION_CLS,):
-            raise TypeError(f"Class {typename} must be inherited directly from FactDefinition only."
-                            f" Mixins and transitive inheritance are not currently supported")
+            raise TypeError("Class '{}' must be inherited directly from FactDefinition only."
+                            " Mixins and transitive inheritance are not currently supported".format(typename))
 
         annotations = class_attr.get("__annotations__")
 
         if not annotations:
-            raise TypeError(f"No annotations declared in fact definition class '{typename}'")
+            raise TypeError("No annotations declared in fact definition class '{}'".format(typename))
 
-        generated_fact_cls = fact(f"{type}AutoGen", list(annotations))
+        generated_fact_cls = fact("{}AutoGen".format(typename), list(annotations))
 
         new_base_classes = (generated_fact_cls,)
 

--- a/yargy/interpretation/fact.py
+++ b/yargy/interpretation/fact.py
@@ -1,10 +1,6 @@
 # coding: utf-8
 from __future__ import unicode_literals
 
-import six
-
-import sys
-
 from collections import OrderedDict
 
 from yargy.utils import Record, KVRecord
@@ -70,54 +66,6 @@ def fact(name, attributes):
         setattr(cls, str(key), attribute)
 
     return cls
-
-
-_PY36 = sys.version_info[:2] >= (3, 6)
-
-
-# TODO CONSIDER: research ability to use directly with Fact class with backward compatibility saving
-class FactDefinitionMeta(type):
-    BASE_FACT_DEFINITION_CLS = None
-
-    def __new__(mcs, typename, base_classes, class_attr):
-        if class_attr.get('_ROOT_FACT_DEFINITION', False):
-            # Checking for attempt to redeclare base definition class
-            if mcs.BASE_FACT_DEFINITION_CLS is not None:
-                raise TypeError(
-                    "Attempt to redeclare base fact definition class"
-                    " '{current_base_cls_name}' by '{new_base_cls_name}'".format(
-                        current_base_cls_name=mcs.BASE_FACT_DEFINITION_CLS.__name__,
-                        new_base_cls_name=typename
-                    )
-                )
-
-            # Saving root class to metaclass attributes
-            mcs.BASE_FACT_DEFINITION_CLS = super(FactDefinitionMeta, mcs).__new__(mcs, typename, base_classes, class_attr)
-            return mcs.BASE_FACT_DEFINITION_CLS
-
-        if not _PY36:
-            raise TypeError("Class-bases fact definition syntax is only supported in Python 3.6+")
-
-        # TODO CONSIDER: research ability of mixins support
-        # TODO CONSIDER: research ability of transitive inheritance from base class
-        if base_classes != (mcs.BASE_FACT_DEFINITION_CLS,):
-            raise TypeError("Class '{}' must be inherited directly from FactDefinition only."
-                            " Mixins and transitive inheritance are not currently supported".format(typename))
-
-        annotations = class_attr.get("__annotations__")
-
-        if not annotations:
-            raise TypeError("No annotations declared in fact definition class '{}'".format(typename))
-
-        generated_fact_cls = fact("{}AutoGen".format(typename), list(annotations))
-
-        new_base_classes = (generated_fact_cls,)
-
-        return super(FactDefinitionMeta, mcs).__new__(mcs, typename, new_base_classes, class_attr)
-
-
-class FactDefinition(six.with_metaclass(FactDefinitionMeta, Fact)):
-    _ROOT_FACT_DEFINITION = True
 
 
 class InterpretatorFact(Record):

--- a/yargy/interpretation/fact.py
+++ b/yargy/interpretation/fact.py
@@ -1,6 +1,8 @@
 # coding: utf-8
 from __future__ import unicode_literals
 
+import sys
+
 from collections import OrderedDict
 
 from yargy.utils import Record, KVRecord
@@ -66,6 +68,49 @@ def fact(name, attributes):
         setattr(cls, str(key), attribute)
 
     return cls
+
+
+_PY36 = sys.version_info[:2] >= (3, 6)
+
+
+# TODO CONSIDER: research ability to use directly with Fact class with backward compatibility saving
+class FactDefinitionMeta(type):
+    BASE_FACT_DEFINITION_CLS = None
+
+    def __new__(mcs, typename, base_classes, class_attr):
+        if class_attr.get('_ROOT_FACT_DEFINITION', False):
+            # Checking for attempt to redeclare base definition class
+            if mcs.BASE_FACT_DEFINITION_CLS is not None:
+                raise TypeError(f"Attempt to redeclare base fact definition class "
+                                f"'{mcs.BASE_FACT_DEFINITION_CLS.__name__}' by '{typename}'")
+
+            # Saving root class to metaclass attributes
+            mcs.BASE_FACT_DEFINITION_CLS = super().__new__(mcs, typename, base_classes, class_attr)
+            return mcs.BASE_FACT_DEFINITION_CLS
+
+        if not _PY36:
+            raise TypeError("Class-bases fact definition syntax is only supported in Python 3.6+")
+
+        # TODO CONSIDER: research ability of mixins support
+        # TODO CONSIDER: research ability of transitive inheritance from base class
+        if base_classes != (mcs.BASE_FACT_DEFINITION_CLS,):
+            raise TypeError(f"Class {typename} must be inherited directly from FactDefinition only."
+                            f" Mixins and transitive inheritance are not currently supported")
+
+        annotations = class_attr.get("__annotations__")
+
+        if not annotations:
+            raise TypeError(f"No annotations declared in fact definition class '{typename}'")
+
+        generated_fact_cls = fact(f"{type}AutoGen", list(annotations))
+
+        new_base_classes = (generated_fact_cls,)
+
+        return super().__new__(mcs, typename, new_base_classes, class_attr)
+
+
+class FactDefinition(Fact, metaclass=FactDefinitionMeta):
+    _ROOT_FACT_DEFINITION = True
 
 
 class InterpretatorFact(Record):

--- a/yargy/interpretation/fact.py
+++ b/yargy/interpretation/fact.py
@@ -1,6 +1,8 @@
 # coding: utf-8
 from __future__ import unicode_literals
 
+import six
+
 import sys
 
 from collections import OrderedDict
@@ -114,8 +116,7 @@ class FactDefinitionMeta(type):
         return super(FactDefinitionMeta, mcs).__new__(mcs, typename, new_base_classes, class_attr)
 
 
-class FactDefinition(Fact):
-    __metaclass__ = FactDefinitionMeta
+class FactDefinition(six.with_metaclass(FactDefinitionMeta, Fact)):
     _ROOT_FACT_DEFINITION = True
 
 

--- a/yargy/interpretation/fact.py
+++ b/yargy/interpretation/fact.py
@@ -114,7 +114,8 @@ class FactDefinitionMeta(type):
         return super().__new__(mcs, typename, new_base_classes, class_attr)
 
 
-class FactDefinition(Fact, metaclass=FactDefinitionMeta):
+class FactDefinition(Fact):
+    __metaclass__ = FactDefinitionMeta
     _ROOT_FACT_DEFINITION = True
 
 

--- a/yargy/interpretation/fact.py
+++ b/yargy/interpretation/fact.py
@@ -90,7 +90,7 @@ class FactDefinitionMeta(type):
                 )
 
             # Saving root class to metaclass attributes
-            mcs.BASE_FACT_DEFINITION_CLS = super().__new__(mcs, typename, base_classes, class_attr)
+            mcs.BASE_FACT_DEFINITION_CLS = super(FactDefinitionMeta, mcs).__new__(mcs, typename, base_classes, class_attr)
             return mcs.BASE_FACT_DEFINITION_CLS
 
         if not _PY36:
@@ -111,7 +111,7 @@ class FactDefinitionMeta(type):
 
         new_base_classes = (generated_fact_cls,)
 
-        return super().__new__(mcs, typename, new_base_classes, class_attr)
+        return super(FactDefinitionMeta, mcs).__new__(mcs, typename, new_base_classes, class_attr)
 
 
 class FactDefinition(Fact):

--- a/yargy/shortcuts/__init__.py
+++ b/yargy/shortcuts/__init__.py
@@ -1,0 +1,5 @@
+from .interpretation import FactDefinition
+
+__all__ = (
+    "FactDefinition",
+)

--- a/yargy/shortcuts/interpretation.py
+++ b/yargy/shortcuts/interpretation.py
@@ -1,0 +1,55 @@
+from __future__ import unicode_literals
+
+import six
+
+import sys
+
+from yargy.interpretation.fact import Fact, fact
+
+_PY36 = sys.version_info[:2] >= (3, 6)
+
+
+# TODO CONSIDER: research ability to use directly with Fact class with backward compatibility saving
+class FactDefinitionMeta(type):
+    BASE_FACT_DEFINITION_CLS = None
+
+    def __new__(mcs, typename, base_classes, class_attr):
+        if class_attr.get('_ROOT_FACT_DEFINITION', False):
+            # Checking for attempt to redeclare base definition class
+            if mcs.BASE_FACT_DEFINITION_CLS is not None:
+                raise TypeError(
+                    "Attempt to redeclare base fact definition class"
+                    " '{current_base_cls_name}' by '{new_base_cls_name}'".format(
+                        current_base_cls_name=mcs.BASE_FACT_DEFINITION_CLS.__name__,
+                        new_base_cls_name=typename
+                    )
+                )
+
+            # Saving root class to metaclass attributes
+            mcs.BASE_FACT_DEFINITION_CLS = super(FactDefinitionMeta, mcs).__new__(mcs, typename, base_classes,
+                                                                                  class_attr)
+            return mcs.BASE_FACT_DEFINITION_CLS
+
+        if not _PY36:
+            raise TypeError("Class-bases fact definition syntax is only supported in Python 3.6+")
+
+        # TODO CONSIDER: research ability of mixins support
+        # TODO CONSIDER: research ability of transitive inheritance from base class
+        if base_classes != (mcs.BASE_FACT_DEFINITION_CLS,):
+            raise TypeError("Class '{}' must be inherited directly from FactDefinition only."
+                            " Mixins and transitive inheritance are not currently supported".format(typename))
+
+        annotations = class_attr.get("__annotations__")
+
+        if not annotations:
+            raise TypeError("No annotations declared in fact definition class '{}'".format(typename))
+
+        generated_fact_cls = fact("{}AutoGen".format(typename), list(annotations))
+
+        new_base_classes = (generated_fact_cls,)
+
+        return super(FactDefinitionMeta, mcs).__new__(mcs, typename, new_base_classes, class_attr)
+
+
+class FactDefinition(six.with_metaclass(FactDefinitionMeta, Fact)):
+    _ROOT_FACT_DEFINITION = True

--- a/yargy/tests/conftest.py
+++ b/yargy/tests/conftest.py
@@ -1,0 +1,10 @@
+from __future__ import unicode_literals
+
+import sys
+
+_PY36 = sys.version_info[:2] >= (3, 6)
+
+collect_ignore = []
+
+if not _PY36:
+    collect_ignore.append("test_class_based_fact_definition.py")

--- a/yargy/tests/test_class_based_fact_definition.py
+++ b/yargy/tests/test_class_based_fact_definition.py
@@ -1,5 +1,7 @@
-from yargy.interpretation.fact import FactDefinition, Fact
+from yargy.interpretation.fact import Fact
 from yargy.interpretation.attribute import Attribute
+
+from yargy.shortcuts import FactDefinition
 
 
 def test_smoke_subclass():

--- a/yargy/tests/test_class_based_fact_definition.py
+++ b/yargy/tests/test_class_based_fact_definition.py
@@ -1,0 +1,19 @@
+from yargy.interpretation.fact import FactDefinition, Fact
+from yargy.interpretation.attribute import Attribute
+
+
+def test_smoke_subclass():
+    class FactCls(FactDefinition):
+        a: str
+        b: str
+
+    assert issubclass(FactCls, Fact)
+
+
+def test_smoke_is_attribute():
+    class FactCls(FactDefinition):
+        a: str
+        b: str
+
+    assert isinstance(FactCls.a, Attribute)
+    assert isinstance(FactCls.b, Attribute)


### PR DESCRIPTION
Всем привет.

Реализовал малоинвазивный способ объявлять классы фактов с использованием аннотаций типов из Py3.6.
Вот пример, как при помощи этого способа создать класс факта.
```python
class Ork(FactDefinition):
    first_name: str
    last_name: str

    @property
    def full_name(self):
        return f"{self.first_name} {self.last_name}"
```
Это будет эквивалент следующего:
```python
OrkAutoGen = fact("OrkAutoGen", [
    "first_name",
    "last_name",
])


class Ork(OrkAutoGen):
    @property
    def full_name(self):
        return f"{self.first_name} {self.last_name}"
```